### PR TITLE
Why getnighthawk section fixes

### DIFF
--- a/docs/_sass/getnighthawk.scss
+++ b/docs/_sass/getnighthawk.scss
@@ -177,6 +177,24 @@ $blue-munsell-3: #4392a4ff;
   font-weight: 490;
   margin-bottom: 20px;
 }
+.why-getnighthawk {
+  text-align: center;
+}
+.why-getnighthawk-h2 {
+  font-size: 50px;
+  line-height: 50px;
+  font-weight: 700;
+  color: #000000;
+}
+.why-getnighthawk-p {
+  font-size: 20px;
+  line-height: 15px;
+  font-weight: 400;
+  color: #000000 60%;
+}
+.why-getnighthawk-p-div {
+  margin-top: 2rem;
+}
 
 // nighthawk-description ends
 
@@ -3834,12 +3852,12 @@ a.globalFooterCard.card-environment, div.globalFooterCard.card-environment {
 }
 
 .section--padding {
-    padding: 60px 0
+    padding: 10px 0
 }
 
 @media (min-width: 670px) {
     .section--padding {
-        padding: 80px 0
+        padding: 10px 0
     }
 }
 

--- a/docs/_sass/getnighthawk.scss
+++ b/docs/_sass/getnighthawk.scss
@@ -3852,12 +3852,12 @@ a.globalFooterCard.card-environment, div.globalFooterCard.card-environment {
 }
 
 .section--padding {
-    padding: 10px 0
+    padding: 60px 0
 }
 
 @media (min-width: 670px) {
     .section--padding {
-        padding: 10px 0
+        padding: 80px 0
     }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,17 +140,34 @@ layout: default
 
   </div>
 
+  <div class="newsletter-signup newsletter-div">
+    <div>
+      <h2 class="why-getnighthawk-h2">
+        Why GetNighthawk?
+      </h2>
+    </div>
+    <div class="why-getnighthawk-p-div">
+      <p class="why-getnighthawk-p">
+        Nighthawk is growing in popularity, but the core project only builds to one architecture / one
+      </p>
+      <p class="why-getnighthawk-p">
+        Docker image. Recently, Nighthawk is being improved so that it can be horizontally scalable - such
+      </p>
+      <p class="why-getnighthawk-p">
+        that multiple instances will be cognizant of one another and able to coordinate amongst each
+      </p>
+      <p class="why-getnighthawk-p">
+        other. Nighthawk is a subproject of Envoy. Nighthawk is growing in popularity with Google, Red
+      </p>
+      <p class="why-getnighthawk-p">
+        Hat, and AWS are investing into it. Istio is considering switching from Fortio to Nighthawk.
+      </p>
+    </div>
+  </div>
+
 <section class="platform section section--padding">
   <div class="container-lg">
     <div class="section-intro ">
-      <div class="section-cust-head">
-        <h2 class="common-PageTitle">
-          Why GetNighthawk?
-        </h2>
-        <p class="common-IntroText">
-          Nighthawk is growing in popularity, but the core project only builds to one architecture / one Docker image. Recently, Nighthawk is being improved so that it can be horizontally scalable - such that multiple instances will be cognizant of one another and able to coordinate amongst each other. Nighthawk is a subproject of Envoy. Nighthawk is growing in popularity with Google, Red Hat, and AWS are investing into it. Istio is considering switching from Fortio to Nighthawk.
-        </p>
-      </div>
       <div class="card-wrapper">
         <div class="card-item item-1">
           <div class="card-head">


### PR DESCRIPTION
Updated the 'why-getnighthawk' section according to the Figma mockup.

This PR fixes #72 

![why-getnighthawk](https://user-images.githubusercontent.com/62200066/109961255-bafc2400-7d0f-11eb-9a20-389f87074985.png)


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
