### PR TITLE
[Site] Fixed docs section padding

### DIFF
--- a/docs/_sass/getnighthawk.scss
+++ b/docs/_sass/getnighthawk.scss
@@ -5936,7 +5936,13 @@ div.globalFooterCard.card-environment {
 /*# sourceMappingURL=about-44bbf7b0a0c8887c2697.min.css.map*/
 
 /* docs styling */
+.doc-container{
+  padding: 10px;
+}
+
 .doc-link {
+  display: inline-block;
+	padding: 5px 0;
   text-decoration: none;
   margin-left: 20px;
   color: #696969;

--- a/docs/pages/docs.html
+++ b/docs/pages/docs.html
@@ -102,10 +102,10 @@ permalink: /docs
                     <h4 class="doc-heading">{{ docs.name }}</h4>
                   </button>
                 </h2>
-                  <div id="flush-collapse{{docs.number}}" class="accordion-collapse collapse" aria-labelledby="flush-heading{{docs.number}}" data-bs-parent="#accordionFlushExample">
+                  <div id="flush-collapse{{docs.number}}" class="accordion-collapse collapse" style="padding: 15px;" aria-labelledby="flush-heading{{docs.number}}" data-bs-parent="#accordionFlushExample">
                     {% for doc in site.docs %}
                       {% if doc.section == docs.name %}
-                        <li>
+                        <li style="padding: 5px 0;">
                           <h5>
                             {% assign foo = docs.name %}
                             <a

--- a/docs/pages/docs.html
+++ b/docs/pages/docs.html
@@ -102,10 +102,10 @@ permalink: /docs
                     <h4 class="doc-heading">{{ docs.name }}</h4>
                   </button>
                 </h2>
-                  <div id="flush-collapse{{docs.number}}" class="accordion-collapse collapse" style="padding: 15px;" aria-labelledby="flush-heading{{docs.number}}" data-bs-parent="#accordionFlushExample">
+                  <div id="flush-collapse{{docs.number}}" class="accordion-collapse collapse doc-container" aria-labelledby="flush-heading{{docs.number}}" data-bs-parent="#accordionFlushExample">
                     {% for doc in site.docs %}
                       {% if doc.section == docs.name %}
-                        <li style="padding: 5px 0;">
+                        <li>
                           <h5>
                             {% assign foo = docs.name %}
                             <a


### PR DESCRIPTION
Signed-off-by: Nikhil <nikhilsharmamusic2000@gmail.com>

**Description**
- There was an issue with section padding on the docs page.

## Before
![Old](https://user-images.githubusercontent.com/58226527/120071098-4a189e00-c0ab-11eb-9abd-7db5af930357.png)

- Added padding around the links

## After Changes
![New](https://user-images.githubusercontent.com/58226527/120071113-53096f80-c0ab-11eb-84e8-96e8c4b3a833.png)


**Notes for Reviewers**
Let me know if we can make any other changes. Thank you.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
