### PR TITLE
[Site] Fixed purpose section list alignment --signoff

### DIFF
--- a/docs/_sass/getnighthawk-purpose.scss
+++ b/docs/_sass/getnighthawk-purpose.scss
@@ -10,12 +10,13 @@
 }
 
 #list {
-    margin-top: 40px;
+    margin-top: 60px;
 
     .title-list{
         font-size: 24px;
         padding-left: 15px;
         margin-bottom: 10px;
+        height:80px;
     }
     p{
         font-size: 20px;
@@ -24,6 +25,7 @@
 
     li {
         margin-bottom: 40px;
+        height: 240px;
     }
 
     #marker{


### PR DESCRIPTION
Signed-off-by: Nikhil <nikhilsharmamusic2000@gmail.com>

**Description**
There was an issue with the alignment of the list in the "Purpose Of GetNighthawk" section.

### Before Changes
![Screenshot from 2021-06-07 18-34-11](https://user-images.githubusercontent.com/58226527/121023367-d8ce9e80-c7c0-11eb-82e0-e2edcd43ec35.png)

### After Changes
- Updated alignment
![Screenshot from 2021-06-07 18-41-47](https://user-images.githubusercontent.com/58226527/121023427-e71cba80-c7c0-11eb-9137-c5faac407b40.png)

**Notes for Reviewers**
Let me know if there are any other changes we can make. Thank you.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
