### PR TITLE
[Site] Fixed padding around docs content --signoff

### DIFF
--- a/docs/_sass/getnighthawk.scss
+++ b/docs/_sass/getnighthawk.scss
@@ -5979,6 +5979,10 @@ margin: 0;
 /*# sourceMappingURL=about-44bbf7b0a0c8887c2697.min.css.map*/
 
 /* docs styling */
+.row .col-lg-9{
+  padding-right: 40px !important;
+}
+
 .doc-container{
   padding: 10px;
 }


### PR DESCRIPTION
Signed-off-by: Nikhil <nikhilsharmamusic2000@gmail.com>

**Description**
There was an issue with padding around the content on the docs page.

## Before Changes
![Screenshot from 2021-06-10 19-22-33](https://user-images.githubusercontent.com/58226527/121542133-8215ce80-ca25-11eb-954b-8bfe9bab640e.png)

## After Changes
![Screenshot from 2021-06-10 19-48-38](https://user-images.githubusercontent.com/58226527/121542169-8a6e0980-ca25-11eb-9c23-b2106cff85f2.png)

**Notes for Reviewers**
Let me know if there are any other changes we can make. Thank you.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
