### PR TITLE
[site] image container size to 50%

### DIFF
--- a/docs/_sass/index.scss
+++ b/docs/_sass/index.scss
@@ -223,7 +223,7 @@ $blue-munsell-3: #4392a4ff;
   display: inline-block;
   text-align: left;
   padding: 1rem 1rem;
-  margin-top: 5rem;
+  margin-top: 0rem;
 }
 .nighthawk-desc-text-meshery {
   display: inline-block;

--- a/docs/_sass/index.scss
+++ b/docs/_sass/index.scss
@@ -216,6 +216,7 @@ $blue-munsell-3: #4392a4ff;
 }
 .description-div {
   text-align: center;
+  flex:1
  
 }
 .nighthawk-desc-text {

--- a/docs/_sass/layout.scss
+++ b/docs/_sass/layout.scss
@@ -493,12 +493,12 @@ hr {
 @media only screen and (max-width: 992px) {
   .custom-desc-div {
     display: flex;
-    flex-direction: column;
+    flex-direction: column-reverse;
     padding: 0rem;
   }
   .description-div-grpc {
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     padding: 0rem;
     margin: 0 !important;
     max-width: 100% !important;
@@ -513,8 +513,8 @@ hr {
     margin-bottom: 6rem !important;
   }
   .nighthawk-img-container {
-    padding-top: 3rem;
     flex: 1;
+    padding-top: 0rem;
   }
 }
 

--- a/docs/_sass/layout.scss
+++ b/docs/_sass/layout.scss
@@ -473,16 +473,20 @@ hr {
   display: flex;
   padding: 0rem 0;
 }
-
+.nighthawk-img-container {
+  flex: 1;
+}
 @media only screen and (max-width: 1300px) {
   .nighthawk-img-container {
     padding-top: 5rem;
+    flex: 1;
   }
 }
 
 @media only screen and (max-width: 1070px) {
   .nighthawk-img-container {
     padding-top: 10rem;
+    flex: 1;
   }
 }
 
@@ -510,6 +514,7 @@ hr {
   }
   .nighthawk-img-container {
     padding-top: 3rem;
+    flex: 1;
   }
 }
 

--- a/docs/_sass/layout.scss
+++ b/docs/_sass/layout.scss
@@ -532,7 +532,7 @@ hr {
   }
   .custom-desc-div {
     display: flex;
-    flex-direction: column;
+    flex-direction: column-reverse;
     padding: 0;
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,7 +93,7 @@ layout: default
       </div>
     <div class="nighthawk-meshery-div">
       <div class="container description-div description-div-grpc">
-        <div class="">
+        <div>
             <div class="nighthawk-desc-text-meshery head-h1">
               <h1 class="desc-h1">Layer 7 Performance Analysis</h1>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@ layout: default
   <section>
 
   <div class="nighthawk-description-div">
-      <div class="custom-desc-div">
+      <div class="custom-desc-div container">
           <div class="nighthawk-img-container">
             <img src="/assets/images/screenshots/meshery-nighthawk-performance-chart.png" />              
           </div>
@@ -93,8 +93,7 @@ layout: default
       </div>
     <div class="nighthawk-meshery-div">
       <div class="container description-div description-div-grpc">
-        <div class="custom-desc-div">
-    
+        <div class="">
             <div class="nighthawk-desc-text-meshery head-h1">
               <h1 class="desc-h1">Layer 7 Performance Analysis</h1>
 


### PR DESCRIPTION
Signed-off-by: Akshit <akshitarora9211@gmail.com>

**Description**
The meshery nighthawk performance chart image is not 50% of its container.

This PR fixes #206 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
