### PR TITLE
use local Docker build script

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,22 +1,22 @@
-name: Build and Publish Assets
+name: Build and Publish Nighthawk Binaries
 on: 
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to be released'
+        description: 'Version of GetNighthawk to be released'
         required: true
         default: 'stable'
       nighthawk_version:
-        description: 'Version of the nighthawk project'
+        description: 'Version of Nighthawk to build'
         required: true
         default: 'main'
 
 jobs:
   release:
-    name: create release
+    name: Create Release
     runs-on: ubuntu-latest
     steps:
-    - name: Create Release
+    - name: Setup Release Assets
       id: create_release
       uses: ncipollo/release-action@v1
       if: startsWith(github.ref, 'refs/tags/') && success()
@@ -28,7 +28,7 @@ jobs:
         omitNameDuringUpdate: true
         replacesArtifacts: true
   build-and-publish:
-    name: build and publish packages
+    name: Build and Publish Nighthawk
     needs: [release]
     strategy:
       max-parallel: 10
@@ -37,7 +37,7 @@ jobs:
         architecture: [amd64]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout nighthawk
+    - name: Checkout Nighthawk
       uses: actions/checkout@v2
       with:
         repository: 'envoyproxy/nighthawk'
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1'
-    - name: Build and release artifacts to Release
+    - name: Build and Publish Assets
       uses: layer5io/getnighthawk@master
       with:
         repo: layer5io/getnighthawk
@@ -55,19 +55,23 @@ jobs:
         token: ${{ secrets.GH_ACCESS_TOKEN }}
         os: ${{ matrix.os }}
         architecture: ${{ matrix.architecture }}
-    - name: Docker login
+    - name: Login to Docker
       if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') && success()
       uses: azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Docker build & tag
+    - name: Checkout GetNighthawk
+      uses: actions/checkout@v2
+      with:
+        repository: 'layer5io/getnighthawk'
+    - name: Build and Tag Docker Image
       run: |
-        cd /home/runner/work/getnighthawk/getnighthawk/ci/docker
-        ./docker_build.sh
+        chmod +x ./ci/docker_build.sh
+        ./ci/docker_build.sh
         docker tag envoyproxy/nighthawk-dev:latest ${{ secrets.IMAGE_NAME }}:latest
         docker tag ${{ secrets.IMAGE_NAME }}:latest ${{ secrets.IMAGE_NAME }}:${{ github.event.inputs.version }}
-    - name: Docker push
+    - name: Push Docker Image
       run: |
         docker push ${{ secrets.IMAGE_NAME }}:latest
         docker push ${{ secrets.IMAGE_NAME }}:${{ github.event.inputs.version }}

--- a/ci/docker_build.sh
+++ b/ci/docker_build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Builds a docker image nighthawk-dev:latest containing the stripped binaries
+# based on a pre-build bazel-bin directory (with "-c opt" set).
+
+# Stop on errors.
+set -e
+
+# NOTE: explicit no -x for verbose commands. Because this is run in CI, doing so may result in
+# publishing sensitive information into public CI logs if someone makes a change in a
+# consuming script that is off guard.
+
+DOCKER_NAME="nighthawk"
+DOCKER_IMAGE_PREFIX="envoyproxy/${DOCKER_NAME}"
+BINARIES=(nighthawk_test_server nighthawk_client nighthawk_service nighthawk_output_transform)
+BAZEL_BIN="$(bazel info -c opt bazel-bin)"
+WORKSPACE="$(bazel info workspace)"
+TMP_DIR="${WORKSPACE}/tmp-docker-build-context"
+
+rm -rf "${TMP_DIR}"
+
+echo "Preparing docker build context in ${TMP_DIR}"
+cp -r "${WORKSPACE}/ci/docker/" "${TMP_DIR}/"
+
+for BINARY in "${BINARIES[@]}"; do
+    echo "Copy and strip ${BINARY}"
+    TARGET="${TMP_DIR}/${BINARY}"
+    # Docker won't follow symlinks
+    cp "${BAZEL_BIN}/${BINARY}" "${TARGET}"
+    chmod +w "${TARGET}"
+    strip --strip-debug "${TARGET}"
+done
+
+cd "${TMP_DIR}"
+echo "running docker build ... "
+docker build -f "${TMP_DIR}/Dockerfile-${DOCKER_NAME}" -t "${DOCKER_IMAGE_PREFIX}-dev:latest" .
+rm -rf "${TMP_DIR}"
+echo "docker build finished"


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

**Description**

Updates build and release workflow to use a local Docker build script instead of referencing the script in Nighthawk.

First step to setup workflow to publish just the `nighthawk_service` binary.

- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
