### PR TITLE
Add WORKSPACE file for running Bazel commands

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,42 @@
+# Workspace file for running Bazel commands
+
+workspace(name = "nighthawk")
+
+load("//bazel:repositories.bzl", "nighthawk_dependencies")
+
+nighthawk_dependencies()
+
+local_repository(
+    name = "envoy_build_config",
+    path = ".",
+)
+
+load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")
+
+envoy_api_binding()
+
+load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
+
+envoy_api_dependencies()
+
+load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
+
+envoy_dependencies()
+
+load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
+
+envoy_dependencies_extra()
+
+load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
+
+envoy_dependency_imports()
+
+# For PIP support:
+load("@rules_python//python:pip.bzl", "pip_install")
+
+# This rule translates the specified requirements.txt into
+# @my_deps//:requirements.bzl, which itself exposes a pip_install method.
+pip_install(
+    name = "python_pip_deps",
+    requirements = "//:requirements.txt",
+)


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

**Description**

This PR adds a WORKSPACE for running Bazel commands for custom Nighthawk builds.

Related to https://github.com/layer5io/getnighthawk/pull/247

- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
