### PR TITLE
Fixed the broken workflow

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   comment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
**Description**

This PR fixes the **broken workflow for label-commentor**
The error
![image](https://github.com/layer5io/getnighthawk/assets/91362589/2cdb030e-b0c3-4cd9-ab47-cc264b8760c0)

Replaced `ubuntu-18.04` to `ubuntu-22.04`

This version of ubuntu is already being used by [layer5io/sistent](https://github.com/layer5io/sistent/actions/runs/6921494597/workflow)
![image](https://github.com/layer5io/getnighthawk/assets/91362589/8dd487ab-ea2d-40ce-91c5-4bf686e9ff0d)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/getnighthawk/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
