### PR TITLE
added copy button issue 337 omesh-omg

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -12,7 +12,8 @@ layout: default
 
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
         <link href="https://fonts.googleapis.com/css?family=Montserrat|Ubuntu&display=swap" rel="stylesheet">
-
+        // for copy button
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
         
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/sidebar_doc.css" />
@@ -111,6 +112,35 @@ layout: default
   </div>
   <div class="col-sm-9 container-g section-content">
     {{category}}
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var codeBlocks = document.querySelectorAll('pre code');
+        codeBlocks.forEach(function (codeBlock) {
+          var button = document.createElement('button');
+          button.className = 'copy-button';
+          // Use Font Awesome icon for copy button
+          button.innerHTML = '<i class="fas fa-copy"></i>';
+          codeBlock.parentNode.insertBefore(button, codeBlock);
+  
+          var clipboard = new ClipboardJS(button, {
+            target: function (trigger) {
+              return trigger.nextElementSibling;
+            }
+          });
+  
+          clipboard.on('success', function (e) {
+            e.clearSelection();
+            // Change icon to checkmark when copied
+            e.trigger.innerHTML = '<i class="fas fa-check"></i>';
+            setTimeout(function () {
+              // Change back to copy icon after a delay
+              e.trigger.innerHTML = '<i class="fas fa-copy"></i>';
+            }, 2000);
+          });
+        });
+      });
+    </script>
+
     {{content}}
   </div>
 </div>

--- a/docs/assets/css/copy-button.css
+++ b/docs/assets/css/copy-button.css
@@ -21,7 +21,10 @@
 .highlight{
     display: inline-flex;
     position: relative;
-   
+    margin-bottom: 0px;
     width: 100%;
    
+}
+div.highlight {
+  margin-bottom: 16px;
 }

--- a/docs/assets/css/copy-button.css
+++ b/docs/assets/css/copy-button.css
@@ -13,8 +13,8 @@
   }
   
   .copy-button:hover {
-    background-color: #00B39F;
-    border-color: #00B39F;
+    background-color: #00cc99;
+    border-color: #00cc99;
   }
   
   

--- a/docs/assets/css/copy-button.css
+++ b/docs/assets/css/copy-button.css
@@ -1,0 +1,27 @@
+.copy-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 5px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    border: 1px solid #009E7F;
+    border-radius: 3px;
+    background-color: #009E7F;
+    color: #fff;
+    
+  }
+  
+  .copy-button:hover {
+    background-color: #00B39F;
+    border-color: #00B39F;
+  }
+  
+  
+.highlight{
+    display: inline-flex;
+    position: relative;
+   
+    width: 100%;
+   
+}

--- a/docs/assets/css/copy-button.css
+++ b/docs/assets/css/copy-button.css
@@ -5,9 +5,9 @@
     padding: 5px 10px;
     font-size: 14px;
     cursor: pointer;
-    border: 1px solid #009E7F;
+    border: 1px solid #3ab09e;
     border-radius: 3px;
-    background-color: #009E7F;
+    background-color: #3ab09e;
     color: #fff;
     
   }

--- a/docs/assets/css/getnighthawk.css
+++ b/docs/assets/css/getnighthawk.css
@@ -9,5 +9,6 @@ code {
     background-color: black;
     border: 0px;
     padding: .35rem;
+    overflow: hidden;
     /* margin-bottom: 0rem; */
 }

--- a/docs/assets/css/getnighthawk.css
+++ b/docs/assets/css/getnighthawk.css
@@ -3,12 +3,13 @@ pre {
 }
 code {
     border: 0px;
+    overflow-y: hidden;
 }
 .highlight {
     color: white;
     background-color: black;
     border: 0px;
     padding: .35rem;
-    overflow: hidden;
+    overflow-y: hidden;
     /* margin-bottom: 0rem; */
 }

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -8,3 +8,4 @@
 @import "about.scss";
 @import "mailing-list.scss";
 @import "index.scss";
+@import "copy-button.css";


### PR DESCRIPTION
**Description**
this PR adds a copy-button icon to code blocks in documentation
This PR fixes #337 

**Notes for Reviewers**
I have added the button using javascript dom manipulation by searching all the code blocks and
adding the button to them in the code and than there is a CSS file for button, and also imported clipboard.min.js for copy function.

https://github.com/layer5io/getnighthawk/assets/64972958/b5590516-8114-4d19-8ba8-4cd831d987b7



**[Signed commits](https://github.com/layer5io/getnighthawk/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 


