### PR TITLE
fix: Responsive issue in Docs pages

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -18,7 +18,7 @@
 						{% endfor %}
 					</ul>
 					{% endfor %}
-
+					
 				</div>
 				<div class="footer-columns2">
 					{% for column in site.data.footer %}

--- a/docs/_sass/getnighthawk.scss
+++ b/docs/_sass/getnighthawk.scss
@@ -5016,6 +5016,11 @@ div.globalFooterCard.card-environment {
   }
 }
 
+.docs-section{
+  position: relative;
+  top: 6rem;
+}
+
 .rooted-pillar {
   position: relative;
   margin: 0 0 30px;
@@ -5853,7 +5858,7 @@ div.globalFooterCard.card-environment {
 
 .section-content {
   padding-left: 40px !important;
-  margin-top: 30px !important;
+  margin-top: 8rem !important;
   margin-bottom: 50px !important;
   min-height: 100vh;
 }

--- a/docs/_sass/index.scss
+++ b/docs/_sass/index.scss
@@ -152,7 +152,7 @@ $blue-munsell-3: #4392a4ff;
 .newsletter-signup {
   text-align: center;
   padding-top: 0.2rem;
-  padding-bottom: 0.2rem;
+  padding-bottom: 10rem;
 }
 .newsletter-signup-logo {
   width: 15rem;


### PR DESCRIPTION
**Description**

This PR fixes #359 

**Notes for Reviewers**
I have improved the alignment of containers that were look like this
![image](https://github.com/user-attachments/assets/711d6ac9-48a6-4658-a7b4-bf1e75d568fd)
**And now after changes**

![image](https://github.com/user-attachments/assets/e22c7ecc-cb76-4a7a-9ff1-29b5dc7b18b2)


Also improved ``footer's`` position as it was overlapping after i made some changes in some ``docs-pages``

I also improved Css of https://getnighthawk.dev/docs/functionality/performance-benchmarking/
Now looking like this
![image](https://github.com/user-attachments/assets/4cb75715-2fba-48b6-98fb-b5900221dfd3)




**[Signed commits](https://github.com/layer5io/getnighthawk/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
